### PR TITLE
Change $message to $method

### DIFF
--- a/YiiApns.php
+++ b/YiiApns.php
@@ -110,7 +110,7 @@ class YiiApns extends YiiApnsGcmBase
         $message = new ApnsPHP_Message($token);
         $message->setText($text);
         foreach($args as $method => $value) {
-			if (strpos($message, 'set') === false) {
+			if (strpos($method, 'set') === false) {
 				$method = 'set' . ucfirst($method);
 			}
 			$value = is_array($value) ? $value : array($value);

--- a/YiiApns.php
+++ b/YiiApns.php
@@ -154,7 +154,7 @@ class YiiApns extends YiiApnsGcmBase
         }
         $message->setText($text);
         foreach($args as $method => $value) {
-			if (strpos($message, 'set') === false) {
+			if (strpos($method, 'set') === false) {
 				$method = 'set' . ucfirst($method);
 			}
 			$value = is_array($value) ? $value : array($value);


### PR DESCRIPTION
There's a bug where the code is checking if $message contains "step". Instead, it should check if $method contains "step". Otherwise, messages that have the character sequence "step" will fail to tack on "step".
